### PR TITLE
Fix PDU parsing in Association

### DIFF
--- a/lib/dicom_net/pdu.ex
+++ b/lib/dicom_net/pdu.ex
@@ -136,6 +136,10 @@ defmodule DicomNet.Pdu do
     }
   end
 
+  def from_data(data) when byte_size(data) < 6 do
+    {:error, :no_pdu, <<>>}
+  end
+
   def from_data(data) do
     <<type::8, _r::8, length::32, _rest::binary>> = data
     full_pdu_length = length + 6


### PR DESCRIPTION
Handle the case where multiple PDUs are in the association buffer already and calling gen_tcp.recv would lead to a timeout.

Fixes #5