### PR TITLE
Association handler

### DIFF
--- a/lib/dicom_net/association.ex
+++ b/lib/dicom_net/association.ex
@@ -101,14 +101,14 @@ defmodule DicomNet.Association do
     {new_state, response}
   end
 
-  defp reject_association(state, association_data) do
+  defp reject_association(state, association_data, source, reason) do
     new_state =
       state
       |> Map.put(:state, :association_release_request)
       |> Map.put(:association, association_data)
 
     response =
-      Pdu.new_association_reject_response_pdu()
+      Pdu.new_association_reject_response_pdu(source, reason)
       |> Pdu.serialize()
 
     {new_state, response}
@@ -144,10 +144,10 @@ defmodule DicomNet.Association do
               association_data = validate_associate_request(associate_request, :accept)
               accept_association(state, association_data)
 
-            :reject ->
+            {:reject, source, reason} ->
               Logger.debug("Association rejected by handler.")
               association_data = validate_associate_request(associate_request, :reject)
-              reject_association(state, association_data)
+              reject_association(state, association_data, source, reason)
           end
       end
 

--- a/lib/dicom_net/association.ex
+++ b/lib/dicom_net/association.ex
@@ -136,30 +136,31 @@ defmodule DicomNet.Association do
     # If the :association handler is defined 
     # the acceptance/rejection can be handled by
     # the host application.
-    {new_state, response} = 
-        case Keyword.fetch(state.handlers, :association) do
-          :error ->
-            # If no handler is defined simply allow association.
-            Logger.debug("No association hanndler is defined. Accept association.")
-            association_data = accept_associate_request(associate_request)
-            accept_association(state, association_data)
+    {new_state, response} =
+      case Keyword.fetch(state.handlers, :association) do
+        :error ->
+          # If no handler is defined simply allow association.
+          Logger.debug("No association hanndler is defined. Accept association.")
+          association_data = accept_associate_request(associate_request)
+          accept_association(state, association_data)
 
-          {:ok, association_handler} ->
-            # If a handler is defined it must return
-            # :accept or :reject
-            Logger.debug("Association hanndler is defined. Let's pass association_data to it.")
-            case association_handler.(associate_request) do
-              :accept -> 
-                Logger.debug("Association accepted by handler.")
-                association_data = accept_associate_request(associate_request)
-                accept_association(state, association_data)
+        {:ok, association_handler} ->
+          # If a handler is defined it must return
+          # :accept or :reject
+          Logger.debug("Association hanndler is defined. Let's pass association_data to it.")
 
-              :reject ->
-                Logger.debug("Association rejected by handler.")
-                association_data = reject_associate_request(associate_request)
-                reject_association(state, association_data)
-            end
-        end
+          case association_handler.(associate_request) do
+            :accept ->
+              Logger.debug("Association accepted by handler.")
+              association_data = accept_associate_request(associate_request)
+              accept_association(state, association_data)
+
+            :reject ->
+              Logger.debug("Association rejected by handler.")
+              association_data = reject_associate_request(associate_request)
+              reject_association(state, association_data)
+          end
+      end
 
     {new_state, response}
   end

--- a/lib/dicom_net/pdu.ex
+++ b/lib/dicom_net/pdu.ex
@@ -9,6 +9,7 @@ defmodule DicomNet.Pdu do
   @pdu_types %{
     1 => :associate_request,
     2 => :associate_accept,
+    3 => :association_reject_response,
     4 => :data,
     5 => :association_release_request,
     6 => :association_release_response
@@ -258,6 +259,11 @@ defmodule DicomNet.Pdu do
     data
   end
 
+  def serialize(%Pdu{type: :association_reject_response}) do
+    # TODO: for now a hardcoded Reject Permanent, Calling AETitle not recognized is returned
+    <<3::8, 0::8, 4::32, 0::8, 1::8, 1::8, 3::8>>
+  end
+
   def new_associate_accept_response_pdu(association_data) do
     %Pdu{
       type: :associate_accept_response,
@@ -288,6 +294,14 @@ defmodule DicomNet.Pdu do
   def new_association_release_response_pdu() do
     %Pdu{
       type: :association_release_response,
+      length: 0,
+      data: nil
+    }
+  end
+
+  def new_association_reject_response_pdu() do
+    %Pdu{
+      type: :association_reject_response,
       length: 0,
       data: nil
     }

--- a/lib/dicom_net/pdu.ex
+++ b/lib/dicom_net/pdu.ex
@@ -259,9 +259,46 @@ defmodule DicomNet.Pdu do
     data
   end
 
-  def serialize(%Pdu{type: :association_reject_response}) do
+  def serialize(%Pdu{type: :association_reject_response, data: data}) do
+    # https://dicom.nema.org/dicom/2013/output/chtml/part08/sect_9.3.html#table_9-21
+    %{
+      source: source,
+      reason: reason
+    } = data
+
     # TODO: for now a hardcoded Reject Permanent, Calling AETitle not recognized is returned
-    <<3::8, 0::8, 4::32, 0::8, 1::8, 1::8, 3::8>>
+    header = <<3::8, 0::8, 4::32, 0::8, 1::8>>
+    case source do
+      :dicom_ul_service_user ->
+        case reason do
+          :no_reason_given ->
+            header <> <<1::8, 1::8>>
+          :application_context_name_not_supported ->
+            header <> <<1::8, 2::8>>
+          :calling_ae_title_not_recognized ->
+            header <> <<1::8, 3::8>>
+          :called_ae_title_not_recognized ->
+            header <> <<1::8, 7::8>>
+        end
+
+      :dicom_ul_service_provider_acse ->
+        case reason do
+          :no_reason_given ->
+            header <> <<1::8, 1::8>>
+          :protocol_version_not_supported ->
+            header <> <<1::8, 2::8>>
+        end
+
+      :dicom_ul_service_provider_presentation ->
+        case reason do
+          :no_reason_given ->
+            header <> <<1::8, 1::8>>
+          :protocol_version_not_supported ->
+            header <> <<1::8, 2::8>>
+        end
+    end
+   
+   
   end
 
   def new_associate_accept_response_pdu(association_data) do
@@ -299,11 +336,13 @@ defmodule DicomNet.Pdu do
     }
   end
 
-  def new_association_reject_response_pdu() do
+  def new_association_reject_response_pdu(source, reason) do
     %Pdu{
       type: :association_reject_response,
-      length: 0,
-      data: nil
+      data: %{
+        source: source,
+        reason: reason
+      }
     }
   end
 end

--- a/lib/dicom_net/pdu.ex
+++ b/lib/dicom_net/pdu.ex
@@ -266,7 +266,6 @@ defmodule DicomNet.Pdu do
       reason: reason
     } = data
 
-    # TODO: for now a hardcoded Reject Permanent, Calling AETitle not recognized is returned
     header = <<3::8, 0::8, 4::32, 0::8, 1::8>>
     case source do
       :dicom_ul_service_user ->


### PR DESCRIPTION
Hi @jjedele!, I'm implementing a new handler for Association accept/reject.

The api is similar to the other handlers, it can evaluate `association_data` and `:accept` or `:reject`. If no association handler is defined always accept. for example:

```elixir
defmodule Worklist do
  use Application
                                                
  def start(_type, _args) do
    {:ok, endpoint_pid} = GenServer.start_link( 
      DicomNet.Endpoint,
      port: 4242,
      event_handlers: [
        association: &association_handler/1,
      ]
    )

    loop()
    {:ok, endpoint_pid}
  end
  
  defp association_handler(association_data) do
    IO.inspect(association_data)
    case association_data.called_ae_title do
      "TEST" ->
        :accept
      _ ->
        :reject
    end
  end 
end
```